### PR TITLE
Expand pattern explanations and rationale

### DIFF
--- a/.codex/study-docs/design-patterns-current.md
+++ b/.codex/study-docs/design-patterns-current.md
@@ -29,6 +29,8 @@ Use this file to:
 
 Definition:
 - Encapsulates data-access behavior behind repository interfaces.
+- In practice here, it creates a boundary between domain/application logic and persistence mechanics (JSON records, file IO, mapping, and storage shape).
+- It gives services a stable contract focused on business intent (users, products, orders), not storage internals.
 
 Where implemented:
 - Contracts:
@@ -45,17 +47,35 @@ Why used here:
 - keeps services and menus storage-agnostic
 - isolates JSON and file mechanics from business workflows
 
+Expanded explanation:
+- Application services (`UserService`, `ProductService`, `OrderService`) coordinate use-cases. They should answer business questions, not decide how files are loaded/saved.
+- Repository interfaces let the application layer ask for domain entities while infrastructure handles conversion to/from persistence record models.
+- The `JsonFileStore` concern stays localized to infrastructure, which reduces accidental coupling between business rules and storage details.
+
+Why this choice is strong for Submission 2:
+- Submission 2 increased orchestration complexity (command dispatch, strategy seams, role workspaces). Keeping persistence concerns behind repositories prevents that complexity from leaking across layers.
+- Repository contract tests lock expected behavior regardless of implementation details, so refactors are safer.
+- It preserves a low-risk path for future storage replacement (for example, database-backed repositories) without rewriting menu/service orchestration.
+
 Trade-off:
 - extra interfaces and mapping maintenance overhead
+
+Common arguments and rebuttals:
+- Argument: "For a small console app, repositories are over-engineering."
+- Rebuttal: The project already has multiple aggregates (`User`, `Product`, `Order`) and non-trivial workflows; repository seams paid off immediately through contract tests and cleaner services.
+- Argument: "Just use one generic repository and skip specific interfaces."
+- Rebuttal: Aggregate-specific interfaces communicate intent and prevent leaking query/storage concerns into services; this keeps domain rules readable and cohesive.
+- Argument: "Services could call `JsonFileStore` directly."
+- Rebuttal: That would mix IO, mapping, and business decisions in the same classes, increasing churn and making tests brittle.
 
 Evidence in tests:
 - `Tests/CommerceConsole.Tests/Infrastructure/RepositoryContractTests.cs`
 - `Tests/CommerceConsole.Tests/Infrastructure/JsonPersistenceTests.cs`
-
 ## 2. Strategy Pattern
 
 Definition:
 - Encapsulates interchangeable algorithms behind a common contract.
+- In this codebase, strategy boundaries isolate "how a variable action is executed" from "when and why that action is invoked."
 
 Where implemented (payment):
 - `Application/Interfaces/IPaymentStrategy.cs`
@@ -71,18 +91,36 @@ Why used here:
 - payment behavior varies independently from checkout orchestration
 - export format varies independently from report aggregation
 
+Expanded explanation:
+- `OrderService` owns checkout workflow and business guards; payment execution itself is delegated to `IPaymentStrategy`.
+- `ReportExportService` owns report assembly/use-case flow; output-format behavior is delegated to `IReportExporter`.
+- This separation keeps orchestrators stable while allowing policy/format algorithms to change at their own pace.
+
+Why this choice is strong for Submission 2:
+- Submission 2 formalized payment and export seams as concrete extension points, improving design clarity without changing user-facing behavior.
+- Strategy contracts reduce regression risk by allowing focused unit tests on each algorithm implementation.
+- The architecture remains open for additional payment/export options with minimal code movement in core workflows.
+
 Trade-off:
 - abstraction overhead when only one concrete strategy exists in a seam
+
+Common arguments and rebuttals:
+- Argument: "There is only one payment strategy now; an interface is unnecessary."
+- Rebuttal: The seam is intentional for volatility. Payment rules are likely to evolve first, and strategy makes that change additive instead of invasive.
+- Argument: "A simple `if/else` in `OrderService` is easier."
+- Rebuttal: It is easier short-term, but it couples orchestration and algorithm branches, making checkout harder to test and maintain as options grow.
+- Argument: "Export strategy is premature since only PDF exists."
+- Rebuttal: Export is a classic variability axis; isolating it now keeps reporting logic independent from output tooling and avoids later refactor pressure.
 
 Evidence in tests:
 - `Tests/CommerceConsole.Tests/Application/WalletPaymentStrategyTests.cs`
 - `Tests/CommerceConsole.Tests/Application/OrderServiceTests.cs`
 - `Tests/CommerceConsole.Tests/Infrastructure/PdfReportExporterTests.cs`
-
 ## 3. Factory Pattern
 
 Definition:
 - Centralizes creation/resolution logic so callers do not branch on concrete types.
+- Here, the factory resolves runtime role context into the correct workspace object behind a stable interface.
 
 Where implemented:
 - `Presentation/Workspaces/IUserWorkspace.cs`
@@ -96,17 +134,35 @@ Why used here:
 - removes role-based workspace routing logic from main flow
 - keeps role-to-workspace mapping explicit and testable
 
+Expanded explanation:
+- `MainMenu` should coordinate interaction flow, not know every workspace construction/routing detail.
+- `RoleWorkspaceFactory` is a single decision point for role-to-workspace mapping (`CustomerWorkspace` vs `AdminWorkspace`).
+- Workspace contracts (`IUserWorkspace`) keep menu code focused on behavior, while factory logic stays isolated and easy to verify.
+
+Why this choice is strong for Submission 2:
+- Submission 2 added commandized menus; pairing that with centralized workspace resolution keeps control flow predictable.
+- Factory tests provide direct proof that role routing behavior is correct and stable.
+- It avoids scattering role checks across presentation classes, reducing change risk when roles/workspaces evolve.
+
 Trade-off:
 - one more abstraction layer for simple role count
+
+Common arguments and rebuttals:
+- Argument: "A direct `switch` in `MainMenu` would be shorter."
+- Rebuttal: Shorter initially, but it mixes orchestration with role resolution and encourages duplicated branching as menus evolve.
+- Argument: "Dependency injection alone can resolve workspace instances."
+- Rebuttal: DI creates objects, but the role-based selection policy still needs a clear owner; factory is that policy boundary.
+- Argument: "Factory hides too much logic."
+- Rebuttal: In this design, logic is explicit and test-covered in one place, which is more transparent than branching spread across multiple callers.
 
 Evidence in tests:
 - `Tests/CommerceConsole.Tests/Presentation/RoleWorkspaceFactoryTests.cs`
 - routing assertions in `Tests/CommerceConsole.Tests/Presentation/MenuCommandTests.cs`
-
 ## 4. Command Pattern
 
 Definition:
 - Encapsulates actions as command objects and dispatches by key/context.
+- In this project, each menu action is represented as a command with a standardized execution contract and result model.
 
 Where implemented:
 - Contracts/infrastructure:
@@ -128,12 +184,29 @@ Why used here:
 - standardizes menu dispatch behavior
 - keeps menu loops thinner
 
+Expanded explanation:
+- `MenuCommandDispatcher` maps user selections to commands and enforces consistent dispatch behavior across menus.
+- `IMenuCommand` + `MenuCommandResult` unify how commands signal outcomes (continue, route, exit/logout).
+- Dedicated commands for key control-flow transitions (`MainLoginRouteCommand`, `MainExitMenuCommand`, `WorkspaceLogoutCommand`) make navigation rules explicit rather than hidden inside menu loops.
+
+Why this choice is strong for Submission 2:
+- Submission 2 expanded menu behavior while preserving business flow. Command dispatch kept growth manageable without bloated switch blocks.
+- It enables targeted command-level tests and routing assertions, improving confidence in UI control flow.
+- New menu actions can be added with minimal edits to existing menus, lowering regression risk.
+
 Trade-off:
 - more types compared to direct branching
 
+Common arguments and rebuttals:
+- Argument: "Switch statements are easier to read for console menus."
+- Rebuttal: They are fine for tiny static menus, but readability degrades quickly when each case grows behavior, validation, and routing branches.
+- Argument: "Too many command classes add boilerplate."
+- Rebuttal: `DelegateMenuCommand` reduces boilerplate where a full class is unnecessary, while explicit classes remain for important control-flow actions.
+- Argument: "Command indirection hurts performance."
+- Rebuttal: For this IO-driven console app, the overhead is negligible compared to gains in testability, extensibility, and maintainability.
+
 Evidence in tests:
 - `Tests/CommerceConsole.Tests/Presentation/MenuCommandTests.cs`
-
 ---
 
 ## B) Additional Patterns and Architecture Techniques Implemented
@@ -329,4 +402,6 @@ Before any demo/viva:
 1. quote implemented patterns only when asked for concrete implementation
 2. map every claim to exact files and tests
 3. clearly label candidates as "future refactor" to avoid over-claiming
+
+
 


### PR DESCRIPTION
Add expanded explanations, rationale for Submission 2, common arguments & rebuttals, and test evidence for multiple design patterns (Repository, Strategy, Factory, Command) in .codex/study-docs/design-patterns-current.md. Clarifies separation of concerns (e.g., JsonFileStore vs. services), role/workspace factory reasoning, command dispatch benefits, and why seams improve testability and future changes; also includes small formatting/whitespace edits.